### PR TITLE
Adicionar botão importar todos do GitHub

### DIFF
--- a/src/components/layout/repositorio-search-bar.tsx
+++ b/src/components/layout/repositorio-search-bar.tsx
@@ -5,12 +5,14 @@ interface RepositorioSearchBarProps {
   value: string;
   onChange: (v: string) => void;
   onAdd: () => void;
+  onImport: () => void;
 }
 
 export function RepositorioSearchBar({
   value,
   onChange,
   onAdd,
+  onImport,
 }: RepositorioSearchBarProps) {
   return (
     <div className="flex items-center justify-between">
@@ -20,7 +22,12 @@ export function RepositorioSearchBar({
         value={value}
         onChange={(e) => onChange(e.target.value)}
       />
-      <Button onClick={onAdd}>+ Adicionar Repositório</Button>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={onImport}>
+          Importar todos do GitHub
+        </Button>
+        <Button onClick={onAdd}>+ Adicionar Repositório</Button>
+      </div>
     </div>
   );
 }

--- a/src/components/modals/importar-github-modal.tsx
+++ b/src/components/modals/importar-github-modal.tsx
@@ -1,0 +1,279 @@
+import * as React from 'react';
+import { Modal } from '@/components/ui/modal';
+import { Button } from '@/components/ui/button';
+import { teamsService } from '@/services/teams';
+import type { Team } from '@/types/team';
+import type { CreateRepositoryDto } from '@/types/repository';
+import type { BulkCreateResult } from '@/services/repositories';
+
+interface GithubRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  html_url: string;
+  private: boolean;
+}
+
+interface ImportarGithubModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onImport: (repositories: CreateRepositoryDto[]) => Promise<BulkCreateResult>;
+}
+
+type ModalStep = 'config' | 'importing' | 'result';
+
+export function ImportarGithubModal({
+  isOpen,
+  onClose,
+  onImport,
+}: ImportarGithubModalProps) {
+  if (!isOpen) return null;
+  return (
+    <ImportarGithubContent onClose={onClose} onImport={onImport} />
+  );
+}
+
+function ImportarGithubContent({
+  onClose,
+  onImport,
+}: Omit<ImportarGithubModalProps, 'isOpen'>) {
+  const [step, setStep] = React.useState<ModalStep>('config');
+  const [githubToken, setGithubToken] = React.useState('');
+  const [teams, setTeams] = React.useState<Team[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = React.useState('');
+  const [fetchError, setFetchError] = React.useState<string | null>(null);
+  const [result, setResult] = React.useState<BulkCreateResult | null>(null);
+
+  React.useEffect(() => {
+    teamsService.getAll().then(setTeams).catch(console.error);
+  }, []);
+
+  const selectClass =
+    'w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring';
+
+  const handleImport = async () => {
+    setFetchError(null);
+
+    if (!githubToken.trim()) {
+      setFetchError('Informe um token do GitHub.');
+      return;
+    }
+    if (!selectedTeamId) {
+      setFetchError('Selecione um time.');
+      return;
+    }
+
+    setStep('importing');
+
+    try {
+      // Fetch all pages from GitHub API
+      const allRepos: GithubRepo[] = [];
+      let page = 1;
+      const perPage = 100;
+
+      while (true) {
+        const res = await fetch(
+          `https://api.github.com/user/repos?per_page=${perPage}&page=${page}&type=all`,
+          {
+            headers: {
+              Authorization: `Bearer ${githubToken}`,
+              Accept: 'application/vnd.github+json',
+            },
+          },
+        );
+
+        if (!res.ok) {
+          const msg =
+            res.status === 401
+              ? 'Token inválido ou sem permissão.'
+              : `Erro ao buscar repositórios GitHub (${res.status}).`;
+          setFetchError(msg);
+          setStep('config');
+          return;
+        }
+
+        const pageRepos: GithubRepo[] = await res.json();
+        allRepos.push(...pageRepos);
+
+        if (pageRepos.length < perPage) break;
+        page++;
+      }
+
+      if (allRepos.length === 0) {
+        setFetchError('Nenhum repositório encontrado na conta GitHub.');
+        setStep('config');
+        return;
+      }
+
+      const dtos: CreateRepositoryDto[] = allRepos.map((r) => ({
+        name: r.name,
+        githubId: r.id,
+        githubUrl: r.html_url,
+        teamId: selectedTeamId,
+      }));
+
+      const importResult = await onImport(dtos);
+      setResult(importResult);
+      setStep('result');
+    } catch (err) {
+      console.error(err);
+      setFetchError('Erro inesperado ao importar repositórios.');
+      setStep('config');
+    }
+  };
+
+  const handleClose = () => {
+    setStep('config');
+    setGithubToken('');
+    setSelectedTeamId('');
+    setFetchError(null);
+    setResult(null);
+    onClose();
+  };
+
+  // --- Config step ---
+  if (step === 'config') {
+    return (
+      <Modal
+        isOpen
+        onClose={handleClose}
+        title="Importar todos do GitHub"
+        description="Informe seu token do GitHub para buscar e importar todos os repositórios da sua conta."
+        footer={
+          <>
+            <Button variant="outline" onClick={handleClose}>
+              Cancelar
+            </Button>
+            <Button onClick={handleImport}>Importar</Button>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          <div>
+            <label
+              htmlFor="github-token"
+              className="block text-sm font-medium text-foreground mb-1"
+            >
+              Token de acesso pessoal do GitHub
+            </label>
+            <input
+              id="github-token"
+              type="password"
+              value={githubToken}
+              onChange={(e) => setGithubToken(e.target.value)}
+              placeholder="ghp_..."
+              className={selectClass}
+              autoComplete="off"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Necessita da permissão <code>repo</code> (ou{' '}
+              <code>public_repo</code> para repositórios públicos).
+            </p>
+          </div>
+
+          <div>
+            <label
+              htmlFor="import-team"
+              className="block text-sm font-medium text-foreground mb-1"
+            >
+              Vincular ao time
+            </label>
+            <select
+              id="import-team"
+              value={selectedTeamId}
+              onChange={(e) => setSelectedTeamId(e.target.value)}
+              className={selectClass}
+            >
+              <option value="">Selecione um time</option>
+              {teams.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {fetchError && (
+            <p className="text-sm text-red-400">{fetchError}</p>
+          )}
+        </div>
+      </Modal>
+    );
+  }
+
+  // --- Importing step ---
+  if (step === 'importing') {
+    return (
+      <Modal
+        isOpen
+        onClose={() => {}}
+        title="Importando repositórios..."
+        description="Aguarde enquanto buscamos e importamos seus repositórios do GitHub."
+      >
+        <div className="flex flex-col items-center gap-4 py-4">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="text-sm text-muted-foreground">
+            Isso pode levar alguns instantes.
+          </p>
+        </div>
+      </Modal>
+    );
+  }
+
+  // --- Result step ---
+  return (
+    <Modal
+      isOpen
+      onClose={handleClose}
+      title="Importação concluída"
+      description="Veja abaixo o resultado da importação dos repositórios."
+      footer={
+        <Button onClick={handleClose}>Fechar</Button>
+      }
+    >
+      <div className="space-y-4">
+        {/* Success summary */}
+        <div className="flex items-center gap-3 rounded-md bg-green-500/10 border border-green-500/30 px-4 py-3">
+          <span className="text-green-400 text-lg">✓</span>
+          <p className="text-sm text-green-400 font-medium">
+            {result?.created.length ?? 0} repositório(s) importado(s) com
+            sucesso.
+          </p>
+        </div>
+
+        {/* Failures */}
+        {result && result.failed.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium text-foreground">
+              {result.failed.length} falha(s):
+            </p>
+            <div className="max-h-52 overflow-y-auto space-y-1 rounded-md border border-border p-2">
+              {result.failed.map((f, i) => (
+                <div
+                  key={i}
+                  className="flex items-start gap-2 rounded px-2 py-1.5 bg-destructive/10"
+                >
+                  <span className="text-destructive text-xs mt-0.5">✗</span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-foreground truncate">
+                      {f.item.name}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {f.reason}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {result && result.failed.length === 0 && (
+          <p className="text-xs text-muted-foreground text-center">
+            Nenhuma falha registrada.
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/src/hooks/use-repositorios.ts
+++ b/src/hooks/use-repositorios.ts
@@ -5,6 +5,7 @@ import type {
   CreateRepositoryDto,
   UpdateRepositoryDto,
 } from '@/types/repository';
+import type { BulkCreateResult } from '@/services/repositories';
 
 export function useRepositorios() {
   const [repositorios, setRepositorios] = React.useState<Repository[]>([]);
@@ -50,5 +51,13 @@ export function useRepositorios() {
 
   const remove = (id: string) => repositoriesService.delete(id).then(refetch);
 
-  return { repositorios, loading, create, update, remove };
+  const bulkImport = async (
+    repositories: CreateRepositoryDto[],
+  ): Promise<BulkCreateResult> => {
+    const result = await repositoriesService.bulkCreate({ repositories });
+    await refetch();
+    return result;
+  };
+
+  return { repositorios, loading, create, update, remove, bulkImport };
 }

--- a/src/pages/repositorios.tsx
+++ b/src/pages/repositorios.tsx
@@ -5,6 +5,7 @@ import { RepositoriosTable } from '@/components/ui/repositorios-table';
 import { PaginationControls } from '@/components/ui/pagination-controls';
 import { RepositorioFormModal } from '@/components/modals/repositorio-form-modal';
 import { ConfirmDeleteModal } from '@/components/modals/confirm-delete-modal';
+import { ImportarGithubModal } from '@/components/modals/importar-github-modal';
 import { RepositorioHeader } from '@/components/layout/repositorio-header';
 import { RepositorioSearchBar } from '@/components/layout/repositorio-search-bar';
 import { useRepositorios } from '@/hooks/use-repositorios';
@@ -15,7 +16,8 @@ import type {
 } from '@/types/repository';
 
 export function Repositorios() {
-  const { repositorios, loading, create, update, remove } = useRepositorios();
+  const { repositorios, loading, create, update, remove, bulkImport } =
+    useRepositorios();
 
   const [searchTerm, setSearchTerm] = React.useState('');
   const [currentPage, setCurrentPage] = React.useState(1);
@@ -23,6 +25,7 @@ export function Repositorios() {
   const [isCreateOpen, setIsCreateOpen] = React.useState(false);
   const [isEditOpen, setIsEditOpen] = React.useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = React.useState(false);
+  const [isImportOpen, setIsImportOpen] = React.useState(false);
   const [editingRepositorio, setEditingRepositorio] = React.useState<
     Repository | undefined
   >();
@@ -53,6 +56,7 @@ export function Repositorios() {
               setCurrentPage(1);
             }}
             onAdd={() => setIsCreateOpen(true)}
+            onImport={() => setIsImportOpen(true)}
           />
 
           {loading ? (
@@ -127,6 +131,12 @@ export function Repositorios() {
         ruleTitle={
           repositorios.find((r) => r.id === deletingRepositorioId)?.name
         }
+      />
+
+      <ImportarGithubModal
+        isOpen={isImportOpen}
+        onClose={() => setIsImportOpen(false)}
+        onImport={bulkImport}
       />
     </SidebarProvider>
   );

--- a/src/services/repositories.ts
+++ b/src/services/repositories.ts
@@ -5,6 +5,15 @@ import type {
   UpdateRepositoryDto,
 } from '@/types/repository';
 
+export interface BulkCreateRepositoryDto {
+  repositories: CreateRepositoryDto[];
+}
+
+export interface BulkCreateResult {
+  created: Repository[];
+  failed: { item: CreateRepositoryDto; reason: string }[];
+}
+
 export const repositoriesService = {
   getAll: (teamId: string) =>
     http<Repository[]>(`/repositories?teamId=${teamId}`),
@@ -13,6 +22,12 @@ export const repositoriesService = {
 
   create: (dto: CreateRepositoryDto) =>
     http<Repository>('/repositories', {
+      method: 'POST',
+      body: JSON.stringify(dto),
+    }),
+
+  bulkCreate: (dto: BulkCreateRepositoryDto) =>
+    http<BulkCreateResult>('/repositories/bulk', {
       method: 'POST',
       body: JSON.stringify(dto),
     }),


### PR DESCRIPTION
## O que foi feito?
- Adicionado botão "Importar todos do GitHub" na página de repositórios
- Criado modal para informar token do GitHub
- Implementada busca paginada de todos os repositórios via API do GitHub
- Adicionado service para importação em massa

## Como testar?
1. Acesse a página de repositórios
2. Clique em "Importar todos do GitHub"
3. Informe um token válido do GitHub (com permissão `repo`)
4. Selecione um time
5. Confirme a importação

## Observações
- O token é informado pelo usuário, sem necessidade de variáveis de ambiente
- Suporte a paginação (busca todos os repositórios)